### PR TITLE
Amend order of preference for apiUrl client option

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -50,7 +50,7 @@ class Spark extends EventEmitter {
     this.maxPageItems = this.options.maxPageItems || 100;
 
     // api url
-    this.apiUrl = process.env.API_URL || this.options.apiUrl || 'https://api.ciscospark.com/v1/';
+    this.apiUrl = this.options.apiUrl || process.env.API_URL || 'https://api.ciscospark.com/v1/';
 
     // attach resource methods
     _.merge(this, contents(this));


### PR DESCRIPTION
This aligns the order of preference for the apiURL option with the rest of options to first read the value for the options passed, then read from the environment variables, or else use the default value.