### PR TITLE
Extending contentCreate() to fetch files from remote URL

### DIFF
--- a/lib/res/contents.js
+++ b/lib/res/contents.js
@@ -4,8 +4,9 @@ const fs = require('fs');
 const fsp = require('when/node').liftAll(fs);
 const path = require('path');
 const validator = require('../validator');
+var request = require('request');
 
-/**
+/*
  * @description File Object
  *
  * @namespace File
@@ -15,6 +16,7 @@ const validator = require('../validator');
  * @property {Buffer} binary - File contents as binary
  * @property {String} base64 - File contents as base64 encoded string
  */
+
 
 const Contents = (Spark) => {
   const contents = {
@@ -71,7 +73,31 @@ const Contents = (Spark) => {
     contentCreate: (filePath, timeout) => {
       const t = (timeout && typeof _timeout === 'number') ? timeout : 15000;
 
-      if (validator.isFilePath(filePath)) {
+      var isurl=(filePath.slice(0,4)==="http");   // Fetching file from remote URL
+      if(isurl) {
+        var funcc = new Promise(function(resolve, reject){
+        console.log('Downloading via remote URL.');  
+        var url=filePath;
+        request({ url, encoding: null }, (err, resp, buffer) => {
+            console.log("Buffer resolving.");
+            resolve(buffer);
+            console.log("Buffer resolved.");
+            });
+        });
+        
+         return funcc
+         .then((bin) => {
+            const file = {};
+            file.name = path.basename(filePath);
+            file.ext = file.name.split('.').pop();
+            file.type = mime.lookup(file.ext);
+            file.binary = bin;
+            file.base64 = bin.toString('base64');
+            return when(file);
+          });
+      }
+
+      if (validator.isFilePath(filePath) && !isurl) { .  // Fetching file from local URL
         return fsp.readFile(filePath).timeout(t)
           .then((bin) => {
             const file = {};


### PR DESCRIPTION
contentCreate() by default, only supports local file paths in order to create a file object which can be sent as a message in sparky bot. Using request and buffer libraries, a new functionality has been added that enables us to create File Objects from a remote URL path, which should come very handy to directly send the files without ever needing to perform disk operations of any kind, at the server end.