### PR TITLE
Add sparky support for card attachment actions

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -708,6 +708,68 @@ Spark.prototype.personByEmail = function(email) {
 };
 
 /**
+ * @description Return details of an attachment action by ID.
+ *
+ * @function
+ * @param {String} attachmentActionId AttachmentAction ID
+ * @returns {Promise.<AttachmentAction>} AttachmentAction object
+ *
+ * @example
+ * spark.attachmentActionGet('Tm90aGluZyB0byBzZWUgaGVy')
+ *   .then(attachmentAction => console.log(attachmentAction))
+ *   .catch(err => console.error(err));
+ */
+Spark.prototype.attachmentActionGet = function(attachmentActionId) {
+  /**
+   * @description attachmentActionsObject
+   *
+   * @property {String} id - attachmentAction ID
+   * @property {String} roomId - Room ID
+   * @property {String} personId - Person ID
+   * @property {String} type - action tytpe
+   * @property {String} messageId - Message ID
+   * @property {Object} inputs - Card Inputs
+   * @property {String} created - Date Message created (ISO 8601)
+   */
+  if (typeof attachmentActionId !== 'string') {
+    return when.reject(new Error('invalid arguments'));
+  }
+  return this.request('get', 'attachment/actions', attachmentActionId)
+    .then(res => this.toObject(res));
+};
+
+/**
+ * @description Create an Attachment Action.
+ *
+ * @memberof Spark
+ * @function
+ * @param {Object.<AttachmentAction>} attachmentAction Attachment Action to create
+ * @returns {Promise.<AttachmentAction>} AttachmentAction object
+ *
+ * @example
+ * const newAttachmentAction = {
+  *   type: 'submit',
+  *   messageId: 'Tm90aGluZyB0byBzZWUgaGVy',
+  *   "inputs": {
+  *      "Name": "John Andersen",
+  *      "Url": "https://example.com",
+  *      "Email": "john.andersen@example.com",
+  *      "Tel": "+1 408 526 7209"
+  *     }
+  * }
+  *
+  * spark.attachmentActionCreate(newAttachmentAction)
+  *   .then(attachmentAction => console.log(attachmentAction.id))
+  *   .catch(err => console.error(err));
+  */
+Spark.prototype.attachmentActionCreate = function(attachmentAction) {
+  if ((typeof attachmentAction.type !== 'string') || (typeof attachmentAction.inputs !== 'object')) {
+    return when.reject(new Error('invalid arguments'));
+  }
+  return Spark.request('post', 'attachment/actions', attachmentAction);
+};
+ 
+/**
  * Return messages in a Spark Room.
  *
  * @function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1942 @@
+{
+  "name": "node-sparky",
+  "version": "3.1.21",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escape-sequences": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "app-usage-stats": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/app-usage-stats/-/app-usage-stats-0.4.1.tgz",
+      "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "home-path": "^1.0.3",
+        "test-value": "^2.1.0",
+        "usage-stats": "^0.8.2"
+      }
+    },
+    "array-back": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "dev": true,
+      "requires": {
+        "typical": "^2.6.0"
+      }
+    },
+    "array-tools": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
+      "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
+      "dev": true,
+      "requires": {
+        "object-tools": "^1.6.1",
+        "typical": "^2.1"
+      },
+      "dependencies": {
+        "object-tools": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+          "dev": true,
+          "requires": {
+            "array-tools": "^1.8.4",
+            "typical": "^2.2"
+          }
+        }
+      }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "requires": {
+        "readable-stream": "~2.0.5"
+      }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "bottleneck": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-1.12.0.tgz",
+      "integrity": "sha1-qi1AJxATMcmdmDjE15y5KRa8I8U="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cache-point": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
+      "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "fs-then-native": "^1.0.2",
+        "mkdirp": "~0.5.1"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
+    "catharsis": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "cli-commands": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cli-commands/-/cli-commands-0.1.0.tgz",
+      "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^3.0.0",
+        "command-line-args": "^3.0.1",
+        "command-line-commands": "^1.0.4",
+        "command-line-usage": "^3.0.5"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "collect-all": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
+      "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
+      "dev": true,
+      "requires": {
+        "stream-connect": "^1.0.1",
+        "stream-via": "~0.1.0",
+        "typical": "^2.3.0"
+      }
+    },
+    "collect-json": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
+      "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
+      "dev": true,
+      "requires": {
+        "collect-all": "^1.0.2",
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.3"
+      },
+      "dependencies": {
+        "collect-all": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+          "dev": true,
+          "requires": {
+            "stream-connect": "^1.0.2",
+            "stream-via": "^1.0.4"
+          }
+        },
+        "stream-via": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+          "dev": true
+        }
+      }
+    },
+    "column-layout": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
+      "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^2.2.2",
+        "array-back": "^1.0.3",
+        "collect-json": "^1.0.8",
+        "command-line-args": "^2.1.6",
+        "core-js": "^2.4.0",
+        "deep-extend": "~0.4.1",
+        "feature-detect-es6": "^1.2.0",
+        "object-tools": "^2.0.6",
+        "typical": "^2.4.2",
+        "wordwrapjs": "^1.2.0"
+      },
+      "dependencies": {
+        "ansi-escape-sequences": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "collect-all": "~0.2.1"
+          }
+        },
+        "command-line-args": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
+          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "command-line-usage": "^2",
+            "core-js": "^2.0.1",
+            "feature-detect-es6": "^1.2.0",
+            "find-replace": "^1",
+            "typical": "^2.3.0"
+          }
+        },
+        "command-line-usage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
+          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "^2.2.2",
+            "array-back": "^1.0.3",
+            "column-layout": "^2.1.1",
+            "feature-detect-es6": "^1.2.0",
+            "typical": "^2.4.2",
+            "wordwrapjs": "^1.2.0"
+          }
+        },
+        "wordwrapjs": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
+          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.3",
+            "typical": "^2.5.0"
+          }
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "feature-detect-es6": "^1.3.1",
+        "find-replace": "^1.0.2",
+        "typical": "^2.6.0"
+      }
+    },
+    "command-line-commands": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-1.0.4.tgz",
+      "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1"
+      }
+    },
+    "command-line-tool": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
+      "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^2.2.2",
+        "array-back": "^1.0.3",
+        "command-line-args": "^3.0.0",
+        "command-line-usage": "^3.0.3",
+        "feature-detect-es6": "^1.3.0",
+        "typical": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-escape-sequences": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "collect-all": "~0.2.1"
+          }
+        }
+      }
+    },
+    "command-line-usage": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^3.0.0",
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1",
+        "table-layout": "^0.3.0",
+        "typical": "^2.6.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "common-sequence": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "config-master": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-2.0.4.tgz",
+      "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "^6.13.0",
+        "feature-detect-es6": "^1.3.1",
+        "walk-back": "^2.0.1"
+      }
+    },
+    "core-js": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "ddata": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
+      "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "handlebars": "^3.0.3",
+        "marked": "~0.3.6",
+        "object-get": "^2.1.0",
+        "reduce-flatten": "^1.0.1",
+        "string-tools": "^1.0.0",
+        "test-value": "^2.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "defer-promise": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-promise/-/defer-promise-1.0.2.tgz",
+      "integrity": "sha512-5a0iWJvnon50nLLqHPW83pX45BLb4MmlSa1sIg05NBhZoK5EZGz1s8qoZ3888dVGGOT0Ni01NdETuAgdJUZknA==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dmd": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
+      "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "command-line-tool": "~0.5.0",
+        "common-sequence": "^1.0.2",
+        "ddata": "~0.1.25",
+        "file-set": "^1.0.0",
+        "handlebars-array": "^0.2.0",
+        "handlebars-comparison": "^2.0.0",
+        "handlebars-json": "^1.0.0",
+        "handlebars-regexp": "^1.0.0",
+        "handlebars-string": "^2.0.1",
+        "object-tools": "^2.0.6",
+        "reduce-unique": "^1.0.0",
+        "reduce-without": "^1.0.1",
+        "stream-handlebars": "~0.1.6",
+        "string-tools": "^1.0.0",
+        "walk-back": "^2.0.1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "espree": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
+      "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.3.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "feature-detect-es6": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
+      "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4"
+      }
+    },
+    "file-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.2.tgz",
+      "integrity": "sha512-xDXI09w+l+mXxWDym7dQXy3PLdo7DygHlAtRnQ6XIMa0iY/qX6+1J75jjwCArCd48yCiMx2+fRn50BTFd45+jQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "glob": "^7.1.0"
+      }
+    },
+    "filter-where": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
+      "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
+      "dev": true,
+      "requires": {
+        "test-value": "^1.0.1"
+      },
+      "dependencies": {
+        "test-value": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
+        }
+      }
+    },
+    "find-replace": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "requires": {
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
+      }
+    },
+    "fs-then-native": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
+      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
+      "dev": true,
+      "requires": {
+        "feature-detect-es6": "^1.3.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true,
+      "optional": true
+    },
+    "handlebars": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.7.tgz",
+      "integrity": "sha512-Pb/VCTFwbcm3KbD5rIzVVsbVBk7XMfhS4ZIJUfXdMF7H+UngtsofnUBfop/i24GSr3HCDG1PL0KoIX0YqEsXTg==",
+      "dev": true,
+      "requires": {
+        "optimist": "^0.6.1",
+        "source-map": "^0.1.40",
+        "uglify-js": "^2.6"
+      }
+    },
+    "handlebars-array": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
+      "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
+      "dev": true,
+      "requires": {
+        "array-tools": "^1.1.4"
+      }
+    },
+    "handlebars-comparison": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
+      "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
+      "dev": true,
+      "requires": {
+        "array-tools": "^1.1.0"
+      }
+    },
+    "handlebars-json": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
+      "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
+      "dev": true
+    },
+    "handlebars-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
+      "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
+      "dev": true
+    },
+    "handlebars-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
+      "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
+      "dev": true,
+      "requires": {
+        "array-tools": "^1.0.6",
+        "string-tools": "^0.1.4"
+      },
+      "dependencies": {
+        "string-tools": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
+          "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
+          "dev": true
+        }
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-path": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.7.tgz",
+      "integrity": "sha512-tM1pVa+u3ZqQwIkXcWfhUlY3HWS3TsnKsfi2OHHvnhkX52s9etyktPyy1rQotkr0euWimChDq+QkQuDe8ngUlQ==",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "optional": true
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+    },
+    "is-my-json-valid": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js2xmlparser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
+      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdoc-75lb": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
+      "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
+      "dev": true,
+      "requires": {
+        "bluebird": "~3.4.6",
+        "catharsis": "~0.8.8",
+        "escape-string-regexp": "~1.0.5",
+        "espree": "~3.1.7",
+        "js2xmlparser": "~1.0.0",
+        "klaw": "~1.3.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.8.3"
+      }
+    },
+    "jsdoc-api": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
+      "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "cache-point": "~0.3.3",
+        "collect-all": "^1.0.2",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "file-set": "^1.0.1",
+        "jsdoc-75lb": "^3.5.6",
+        "object-to-spawn-args": "^1.1.0",
+        "promise.prototype.finally": "^1.0.1",
+        "temp-path": "^1.0.0",
+        "then-fs": "^2.0.0",
+        "walk-back": "^2.0.1"
+      },
+      "dependencies": {
+        "collect-all": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+          "dev": true,
+          "requires": {
+            "stream-connect": "^1.0.2",
+            "stream-via": "^1.0.4"
+          }
+        },
+        "stream-via": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-parse": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
+      "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^2.2.1",
+        "array-tools": "^2",
+        "collect-json": "^1.0.1",
+        "command-line-args": "^2.1.4",
+        "command-line-tool": "^0.1.0",
+        "core-js": "^2.0.1",
+        "feature-detect-es6": "^1.2.0",
+        "file-set": "~0.2.1",
+        "jsdoc-api": "^1.0.0",
+        "object-tools": "^2",
+        "stream-connect": "^1.0.1",
+        "test-value": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-escape-sequences": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "collect-all": "~0.2.1"
+          }
+        },
+        "array-tools": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
+          "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "^2.2.2",
+            "array-back": "^1.0.2",
+            "collect-json": "^1.0.7",
+            "filter-where": "^1.0.1",
+            "object-get": "^2.0.0",
+            "reduce-extract": "^1.0.0",
+            "reduce-flatten": "^1.0.0",
+            "reduce-unique": "^1.0.0",
+            "reduce-without": "^1.0.0",
+            "sort-array": "^1.0.0",
+            "test-value": "^1.0.1"
+          }
+        },
+        "command-line-args": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
+          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "command-line-usage": "^2",
+            "core-js": "^2.0.1",
+            "feature-detect-es6": "^1.2.0",
+            "find-replace": "^1",
+            "typical": "^2.3.0"
+          }
+        },
+        "command-line-tool": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
+          "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "^2.2.1",
+            "array-back": "^1.0.2"
+          }
+        },
+        "command-line-usage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
+          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "^2.2.2",
+            "array-back": "^1.0.3",
+            "column-layout": "^2.1.1",
+            "feature-detect-es6": "^1.2.0",
+            "typical": "^2.4.2",
+            "wordwrapjs": "^1.2.0"
+          }
+        },
+        "file-set": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
+          "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
+          "dev": true,
+          "requires": {
+            "array-tools": "^2",
+            "glob": "^4"
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "test-value": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
+        },
+        "wordwrapjs": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
+          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.3",
+            "typical": "^2.5.0"
+          }
+        }
+      }
+    },
+    "jsdoc-to-markdown": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-1.3.9.tgz",
+      "integrity": "sha1-d0wOzg69C8wyYbLJoqqNE5mmFHI=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^3.0.0",
+        "command-line-args": "^3.0.1",
+        "command-line-usage": "^3.0.5",
+        "config-master": "^2.0.4",
+        "dmd": "^1.4.1",
+        "jsdoc-parse": "^1.2.7",
+        "jsdoc2md-stats": "^1.0.3",
+        "object-tools": "^2.0.6",
+        "stream-connect": "^1.0.2"
+      }
+    },
+    "jsdoc2md-stats": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/jsdoc2md-stats/-/jsdoc2md-stats-1.0.6.tgz",
+      "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
+      "dev": true,
+      "requires": {
+        "app-usage-stats": "^0.4.0",
+        "feature-detect-es6": "^1.3.1"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lodash": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+      "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true,
+      "optional": true
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mkdirp2": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
+      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
+      "dev": true
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-get": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+      "dev": true
+    },
+    "object-to-spawn-args": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+      "dev": true
+    },
+    "object-tools": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
+      "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.2",
+        "collect-json": "^1.0.7",
+        "object-get": "^2.0.2",
+        "test-value": "^1.1.0",
+        "typical": "^2.4.2"
+      },
+      "dependencies": {
+        "test-value": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "promise.prototype.finally": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
+      "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "reduce-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
+      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "dev": true,
+      "requires": {
+        "test-value": "^1.0.1"
+      },
+      "dependencies": {
+        "test-value": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
+        }
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
+    },
+    "reduce-unique": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
+      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
+      "dev": true
+    },
+    "reduce-without": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
+      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "dev": true,
+      "requires": {
+        "test-value": "^2.0.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "optional": true
+    },
+    "req-then": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/req-then/-/req-then-0.5.1.tgz",
+      "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "defer-promise": "^1.0.0",
+        "feature-detect-es6": "^1.3.1",
+        "lodash.pick": "^4.4.0",
+        "typical": "^2.6.0"
+      }
+    },
+    "request": {
+      "version": "2.74.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "bl": "~1.1.2",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~1.0.0-rc4",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "node-uuid": "~1.4.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1"
+      }
+    },
+    "requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "sort-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
+      "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "object-get": "^2.1.0",
+        "typical": "^2.6.0"
+      }
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "stream-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.2"
+      }
+    },
+    "stream-handlebars": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
+      "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
+      "dev": true,
+      "requires": {
+        "handlebars": "^3.0.0",
+        "object-tools": "^1.2.1"
+      },
+      "dependencies": {
+        "object-tools": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+          "dev": true,
+          "requires": {
+            "array-tools": "^1.8.4",
+            "typical": "^2.2"
+          }
+        }
+      }
+    },
+    "stream-via": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
+      "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
+      "dev": true
+    },
+    "string-tools": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
+      "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "table-layout": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "core-js": "^2.4.1",
+        "deep-extend": "~0.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "typical": "^2.6.0",
+        "wordwrapjs": "^2.0.0-0"
+      }
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
+    "temp-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "dev": true
+    },
+    "test-value": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
+      }
+    },
+    "then-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
+      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+      "dev": true,
+      "requires": {
+        "promise": ">=3.2 <8"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "usage-stats": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/usage-stats/-/usage-stats-0.8.6.tgz",
+      "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "cli-commands": "0.1.0",
+        "core-js": "^2.4.1",
+        "feature-detect-es6": "^1.3.1",
+        "home-path": "^1.0.5",
+        "mkdirp2": "^1.0.3",
+        "req-then": "0.5.1",
+        "typical": "^2.6.1",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "walk-back": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+      "dev": true
+    },
+    "when": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
+      "integrity": "sha1-q6A/w7tzbWyIsJHQE9io5ZDYRxg="
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wordwrapjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+      "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "feature-detect-es6": "^1.3.1",
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sparky",
-  "version": "3.1.21",
+  "version": "3.1.22",
   "description": "Spark SDK for NodeJS",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,10 @@
     "spark teams",
     "spark bot",
     "spark machine accounts",
-    "flint"
+    "flint",
+    "webex",
+    "webex teams",
+    "webex bot"
   ],
   "author": "Nicholas Marus <nmarus@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Webex Bots can now create buttons and cards.   When a user "submits" a response using a card it generates an "attachment action" event.   I plan on updating flint to support buttons and cards, but in order to do this node-sparky lib needs to provide a way to fetch the attachment actions.

https://developer.webex.com/docs/api/v1/attachment-actions